### PR TITLE
feat: bring back example page

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>nftstorage service worker</title>
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register('./nftstorage-sw.js');
+    }
+  </script>
+</head>
+<body>
+  <img src="/ipfs/bafkreigh2akiscaildcqabsyg3dfr6chu3fgpregiymsck7e7aqa4s52zy" alt="room guardian" />
+  <img src="/ipfs/bafybeidluj5ub7okodgg5v6l4x3nytpivvcouuxgzuioa6vodg3xt2uqle/olizilla.png" alt="olizilla" />
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "src/nftstorage-sw.js",
   "scripts": {
+    "start": "cp src/nftstorage-sw.js example && serve example",
     "test": "npm-run-all -p -r mock:nftstorage.link mock:dweb.link test:worker",
     "test:worker": "playwright-test --sw src/nftstorage-sw.js test/browser.test.js",
     "mock:nftstorage.link": "smoke -p 9091 test/mocks/nftstorage.link",
@@ -13,9 +14,11 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^4.3.6",
+    "esbuild-plugin-replace": "^1.2.0",
     "mocha": "^9.2.2",
     "npm-run-all": "^4.1.5",
     "playwright-test": "^7.4.0",
+    "serve": "^13.0.2",
     "smoke": "^3.1.1"
   }
 }

--- a/pw-test.config.js
+++ b/pw-test.config.js
@@ -1,10 +1,14 @@
+const { replace } = require('esbuild-plugin-replace')
+
 /** @type {import('playwright-test').RunnerOptions} */
 module.exports = {
   buildSWConfig: {
-    define: {
-      GATEWAY_URL_GLOBAL: JSON.stringify('http://127.0.0.1:9091'),
-      FALLBACK_URL_GLOBAL: JSON.stringify('http://127.0.0.1:9092'),
-    },
+    plugins: [
+      replace({
+        'https://nftstorage.link': 'http://127.0.0.1:9091',
+        'https://dweb.link': 'http://127.0.0.1:9092'
+      })
+    ]
   },
   beforeTests: async () => {
     console.log('starting')
@@ -14,5 +18,5 @@ module.exports = {
     /** @type {{  mock: ProcessObject }} */ beforeTests
   ) => {
     console.log('⚡️ Shutting down mock servers.')
-  },
+  }
 }

--- a/src/nftstorage-sw.js
+++ b/src/nftstorage-sw.js
@@ -1,5 +1,5 @@
-const GATEWAY_URL = GATEWAY_URL_GLOBAL || 'https://nftstorage.link'
-const FALLBACK_URL = FALLBACK_URL_GLOBAL || 'https://dweb.link'
+const GATEWAY_URL = 'https://nftstorage.link'
+const FALLBACK_URL = 'https://dweb.link'
 const OK_ERROR_STATUS = [
   400,
   404,


### PR DESCRIPTION
- add example dir with index.html to show how to include the service worker in a page
- add esbuild-plugin-replace to simplify replacing the gateway urls

License: (Apache-2.0 AND MIT)
Signed-off-by: Oli Evans <oli@tableflip.io>